### PR TITLE
Fix currentFloor update bug in elevator

### DIFF
--- a/js/managers/ElevatorManager.js
+++ b/js/managers/ElevatorManager.js
@@ -281,7 +281,6 @@ continueElevatorTravel(originalTarget, direction) {
         this.elevatorLightFlicker(1);
 
         this.boardedPlayers.forEach(p => p.y = newY);
-        this.boardedPlayers.forEach(p => p.currentFloor = floor);
         const exiting = this.boardedPlayers.filter(p => p.targetFloor === floor);
         this.boardedPlayers = this.boardedPlayers.filter(p => p.targetFloor !== floor);
 


### PR DESCRIPTION
Remove incorrect `currentFloor` updates during elevator transit to ensure consistent player state.

Previously, `currentFloor` was updated for boarded players at every intermediate floor the elevator passed, conflicting with the intended logic where `currentFloor` should only reflect the floor upon exiting the elevator. This change ensures `currentFloor` accurately represents the player's actual floor.