### PR TITLE
feat: Replace Player boolean flags with explicit state machine

### DIFF
--- a/game.html
+++ b/game.html
@@ -22,6 +22,7 @@
 
 
     <script src="js/GameConfig.js"></script>
+    <script src="js/PlayerStateMachine.js"></script>
     <script src="js/Player.js"></script>
     <script src="js/components/PlayerSprite.js"></script>
     <script src="js/components/Sidebar.js"></script>

--- a/js/GameScene.js
+++ b/js/GameScene.js
@@ -56,9 +56,9 @@ class GameScene extends Phaser.Scene {
         this.selectionPointer = this.add.image(0, 0, 'UI_Pointer_white');
         this.selectionPointer.setOrigin(0.5, 1);
         this.selectionPointer.setScale(2);
-        this.selectionPointer.setVisible(false); 
-        this.selectionPointer.setDepth(30); 
-     
+        this.selectionPointer.setVisible(false);
+        this.selectionPointer.setDepth(30);
+
         // Initialize automated NPC behaviors
         this.initializeNPCBehaviors();
 
@@ -76,58 +76,61 @@ class GameScene extends Phaser.Scene {
                 // Re-enable automation for previously selected player
                 if (this.selectedPlayer && this.selectedPlayer !== (clicked ? clicked.player : null)) {
                     this.selectedPlayer.isAutomated = true;
-                    // Don't interrupt any movement - let them complete their destination
+                    // If they were walking (player-commanded), keep that state
+                    // so they finish their destination before resuming automation.
+                    // Otherwise transition to automated idle.
+                    if (!this.selectedPlayer.is(PlayerState.WALKING)) {
+                        this.selectedPlayer.forceState(PlayerState.AUTOMATED_IDLE);
+                        this.selectedPlayer.idleTimer = 0;
+                        this.selectedPlayer.idleDuration = 1 + Math.random() * 2;
+                    }
                 }
-                
+
                 this.selectedPlayer = clicked ? clicked.player : null;
-                
+
                 // Disable automation for newly selected player
                 if (this.selectedPlayer) {
                     this.selectedPlayer.isAutomated = false;
-                    // Stop any automated movement when selected (but keep player-commanded movement)
-                    if (!this.selectedPlayer.playerCommandedMovement) {
+                    // Stop any automated movement when selected
+                    if (this.selectedPlayer.isAnyOf(PlayerState.AUTOMATED_IDLE, PlayerState.AUTOMATED_WALKING)) {
                         this.selectedPlayer.targetX = null;
                         this.selectedPlayer.vx = 0;
-                        this.selectedPlayer.isWalking = false;
-                        this.selectedPlayer.isIdling = false;
+                        this.selectedPlayer.forceState(PlayerState.IDLE);
                     }
-                    // Note: Keep playerCommandedMovement flag intact so they continue to destination
                 }
-                
+
                 this.sidebar.updatePlayer(this.selectedPlayer);
-                console.log(this.selectedPlayer);
                 return;
             }
 
             const selected = this.selectedPlayer;
             if (!selected) return;
 
-
-
             if (this.elevatorManager.boardedPlayers.includes(selected)) return;
+            if (selected.is(PlayerState.IN_ELEVATOR)) return;
 
-            if(selected.inElevator) return;
- 
-            if (selected) {
-                if(selected.elevatorClickTimer)
-                       selected.elevatorClickTimer.remove();
-
-                selected.waitingForElevator = false;
-                selected.walkingThroughDoor = false;
+            // Cancel any pending elevator or door state
+            if (selected.elevatorClickTimer) {
+                selected.elevatorClickTimer.remove();
+                selected.elevatorClickTimer = null;
             }
-
+            if (selected.isAnyOf(PlayerState.WAITING_FOR_ELEVATOR, PlayerState.WALKING_THROUGH_DOOR, PlayerState.WALKING_TO_ELEVATOR)) {
+                selected.forceState(PlayerState.IDLE);
+            }
 
             const clickedFloor = this.getClickedFloorIndex(pointer.worldY);
             if (clickedFloor === -1) return;
 
             if (clickedFloor !== selected.currentFloor) {
                 selected.deferredTargetX = pointer.worldX;
-                selected.playerCommandedMovement = true;
+                selected.setState(PlayerState.WALKING_TO_ELEVATOR);
                 this.onElevatorZoneClicked(clickedFloor, selected);
-  
             } else {
                 selected.targetX = pointer.worldX;
-                selected.playerCommandedMovement = true;
+                if (selected.is(PlayerState.IDLE)) {
+                    selected.setState(PlayerState.WALKING);
+                }
+                // If already WALKING, state stays the same — just new targetX
             }
         });
 
@@ -146,17 +149,21 @@ class GameScene extends Phaser.Scene {
                 player.minX = 280;
                 player.maxX = 500;
             }
-            
+
             // Initialize automated movement properties
             player.direction = Math.random() > 0.5 ? 1 : -1;
             player.isAutomated = true;
             player.automatedSpeed = GameConfig.CHAR_SPEED * 0.4; // Slower speed for automated NPCs (40% of normal)
             player.idleTimer = 0;
             player.idleDuration = 2 + Math.random() * 3; // Random idle time between 2-5 seconds
-            player.isIdling = false;
+
+            // Start in automated idle, then first movement will begin
+            player.forceState(PlayerState.AUTOMATED_IDLE);
+
             // Start with a random initial movement
             const initialDistance = 60 + Math.random() * 80;
             player.targetX = Math.max(player.minX, Math.min(player.maxX, player.x + (player.direction * initialDistance)));
+            player.setState(PlayerState.AUTOMATED_WALKING);
         });
     }
 
@@ -181,7 +188,7 @@ class GameScene extends Phaser.Scene {
         this.doorManager.addDoor( 3, 436,10, GameConfig.SPRITE_HEIGHT+15,"Door");
         this.doorManager.addDoor( 3, 308,10, GameConfig.SPRITE_HEIGHT+15,"Door");
 
-        
+
     }
 
 createFloorWalls() {
@@ -237,13 +244,13 @@ createFloorWalls() {
         const y = this.getFloorY(cfg.floor);
         const player = new Player(cfg.name[0], cfg.name[1], GameConfig.WINDOW_WIDTH / 2, y, cfg.sprite, cfg.floor);
         const playerSprite = new PlayerSprite(this, player);
-        
+
         // Only create animations once per unique sprite key
         if (!createdAnimations.has(cfg.sprite)) {
             AnimationManager.createAnimations(this, cfg.sprite);
             createdAnimations.add(cfg.sprite);
         }
-        
+
         this.players.push({ player, sprite: playerSprite });
     });
 
@@ -256,7 +263,7 @@ createFloorWalls() {
     }
 
     setupInput() {
-        this.inputManager = new InputManager(this); 
+        this.inputManager = new InputManager(this);
     }
 
     getFloorY(floorIndex) {
@@ -265,7 +272,7 @@ createFloorWalls() {
 
 onElevatorZoneClicked(targetFloor, player) {
     if (!player) return;
-    
+
     // Cancel previous pending movement
     if (player.elevatorClickTimer) {
         player.elevatorClickTimer.remove();
@@ -276,11 +283,12 @@ onElevatorZoneClicked(targetFloor, player) {
     if (player.currentFloor === targetFloor) {
         player.targetX = null;
         player.vx = 0;
+        player.forceState(PlayerState.IDLE);
         return;
     }
 
-    // Case: Already requesting elevator (still allow override if it's a different floor)
-    if (player.inElevator === true) return;
+    // Case: Already in elevator or already has an active request
+    if (player.is(PlayerState.IN_ELEVATOR)) return;
     if (this.elevatorManager.activeRequest && this.elevatorManager.activeRequest.player === player) return;
 
     // Update target floor and set new targetX
@@ -294,7 +302,7 @@ onElevatorZoneClicked(targetFloor, player) {
             const dx = Math.abs(player.x - (this.elevator_X_position+0));
             // Cancel if they somehow entered elevator or changed mind again
             if (
-                player.inElevator === true ||
+                player.is(PlayerState.IN_ELEVATOR) ||
                 player.currentFloor === targetFloor || // Clicked current floor again mid-way
                 (this.elevatorManager.activeRequest && this.elevatorManager.activeRequest.player === player)
             ) {
@@ -309,6 +317,7 @@ onElevatorZoneClicked(targetFloor, player) {
                 player.vx = 0;
                 arrivalCheck.remove();
                 player.elevatorClickTimer = null;
+                player.setState(PlayerState.WAITING_FOR_ELEVATOR);
                 this.elevatorManager.requestElevator(player, targetFloor);
             }
         }
@@ -325,34 +334,32 @@ onElevatorZoneClicked(targetFloor, player) {
         this.players.forEach(({ player, sprite }) => {
             // Update player status (thirst, hunger, sleep)
             player.updateStatus(dt);
-            
+
             // Handle automated NPC behavior
-            if (player.isAutomated && player !== this.selectedPlayer && !player.waitingForElevator && !player.inElevator) {
-                // If they have a player-commanded movement, use normal movement
-                if (player.playerCommandedMovement && player.targetX !== null) {
-                    const previousTargetX = player.targetX;
-                    player.moveTowardTarget(dt);
-                    // Check if they just reached their destination
-                    if (previousTargetX !== null && player.targetX === null) {
-                        player.playerCommandedMovement = false;
-                        player.isIdling = true;
+            if (player.isAutomated && player !== this.selectedPlayer &&
+                !player.isAnyOf(PlayerState.WAITING_FOR_ELEVATOR, PlayerState.IN_ELEVATOR)) {
+
+                if (player.is(PlayerState.WALKING) && player.targetX !== null) {
+                    // Player-commanded movement (from before automation was re-enabled)
+                    const reached = player.moveTowardTarget(dt);
+                    if (reached) {
+                        player.setState(PlayerState.AUTOMATED_IDLE);
                         player.idleTimer = 0;
                         player.idleDuration = 1 + Math.random() * 2;
                     }
-                } else if (player.playerCommandedMovement && player.targetX === null) {
-                    // Edge case: playerCommandedMovement is true but targetX is already null
-                    player.playerCommandedMovement = false;
-                    player.isIdling = true;
+                } else if (player.is(PlayerState.WALKING) && player.targetX === null) {
+                    // Edge case: WALKING but targetX already null
+                    player.setState(PlayerState.AUTOMATED_IDLE);
                     player.idleTimer = 0;
                     player.idleDuration = 1 + Math.random() * 2;
                 } else {
                     this.updateAutomatedBehavior(player, dt);
                 }
             } else {
-                // Regular player movement
+                // Regular player movement (selected player or non-automated)
                 player.moveTowardTarget(dt);
             }
-            
+
             this.checkWallCollision(player, sprite);
             sprite.update();
         });
@@ -363,11 +370,6 @@ onElevatorZoneClicked(targetFloor, player) {
             if (Math.abs(dx) > 0.1) {
                 this.doorManager.tryOpenDoor(player, dx);
             }
-
-            // Reset if player stops moving or exits door area
-            if (Math.abs(dx) < 0.1 && player.hasEnteredDoor) {
-                player.hasEnteredDoor = false;
-            }
         });
 
         if (this.selectionPointer) {
@@ -375,7 +377,7 @@ onElevatorZoneClicked(targetFloor, player) {
                 this.selectionPointer.setVisible(true);
                 this.selectionPointer.x = this.selectedPlayer.x;
                 this.selectionPointer.y = this.selectedPlayer.y - 48; // adjust for head height
-                if(this.selectedPlayer.inElevator)
+                if (this.selectedPlayer.is(PlayerState.IN_ELEVATOR))
                      this.selectionPointer.setVisible(false);
             } else {
                 this.selectionPointer.setVisible(false);
@@ -389,67 +391,63 @@ onElevatorZoneClicked(targetFloor, player) {
     }
 
     updateAutomatedBehavior(player, dt) {
-        if (player.isIdling) {
+        if (player.is(PlayerState.AUTOMATED_IDLE)) {
             // Handle idle state - NPC is stationary
             player.vx = 0;
-            player.isWalking = false;
             player.idleTimer += dt;
-            
+
             if (player.idleTimer >= player.idleDuration) {
                 // End idle period and start moving
-                player.isIdling = false;
                 player.idleTimer = 0;
                 const distance = 60 + Math.random() * 120; // Random movement distance
                 let newTargetX = player.x + (player.direction * distance);
-                
+
                 // If new target would be out of bounds, reverse direction
                 if (newTargetX <= player.minX || newTargetX >= player.maxX) {
                     player.direction *= -1;
                     newTargetX = player.x + (player.direction * distance);
                 }
-                
+
                 // Clamp target within boundaries
                 player.targetX = Math.max(player.minX + 10, Math.min(player.maxX - 10, newTargetX));
-                player.playerCommandedMovement = false; // This is automated movement
+                player.setState(PlayerState.AUTOMATED_WALKING);
             }
-        } else if (player.targetX !== null) {
+        } else if (player.is(PlayerState.AUTOMATED_WALKING) && player.targetX !== null) {
             // Move toward target using slower automated speed
             const originalSpeed = player.speed;
             player.speed = player.automatedSpeed;
             player.moveTowardTarget(dt);
             player.speed = originalSpeed; // Restore original speed
-            
+
             // Check if reached target or boundaries
             const reachedTarget = Math.abs(player.x - player.targetX) < 5;
             const hitBoundary = player.x <= player.minX + 5 || player.x >= player.maxX - 5;
-            
+
             if (reachedTarget || hitBoundary) {
                 // Stop and start idle period
                 player.targetX = null;
                 player.vx = 0;
-                player.isWalking = false;
-                player.isIdling = true;
+                player.setState(PlayerState.AUTOMATED_IDLE);
                 player.idleTimer = 0;
                 player.idleDuration = 1.5 + Math.random() * 3; // Random idle time between 1.5-4.5 seconds
-                
+
                 // If hit boundary, reverse direction for next movement
                 if (hitBoundary) {
                     player.direction *= -1;
                 }
             }
-            
+
             // Small random chance to stop and idle mid-movement
             if (Math.random() < 0.003) {
                 player.targetX = null;
                 player.vx = 0;
-                player.isWalking = false;
-                player.isIdling = true;
+                player.setState(PlayerState.AUTOMATED_IDLE);
                 player.idleTimer = 0;
                 player.idleDuration = 1 + Math.random() * 2;
             }
         } else {
-            // Safety fallback - shouldn't happen, but just in case
-            player.isIdling = true;
+            // Safety fallback — force into automated idle
+            player.forceState(PlayerState.AUTOMATED_IDLE);
             player.idleTimer = 0;
             player.idleDuration = 1 + Math.random() * 2;
         }
@@ -482,15 +480,14 @@ onElevatorZoneClicked(targetFloor, player) {
 
             player.vx = 0;
             player.targetX = null;
-            // Clear the playerCommandedMovement flag since they can't reach their destination
-            if (player.playerCommandedMovement) {
-                player.playerCommandedMovement = false;
-                // If automated, transition to idle
-                if (player.isAutomated) {
-                    player.isIdling = true;
-                    player.idleTimer = 0;
-                    player.idleDuration = 1 + Math.random() * 2;
-                }
+
+            // Transition to appropriate idle state
+            if (player.isAutomated) {
+                player.forceState(PlayerState.AUTOMATED_IDLE);
+                player.idleTimer = 0;
+                player.idleDuration = 1 + Math.random() * 2;
+            } else if (!player.isAnyOf(PlayerState.WAITING_FOR_ELEVATOR, PlayerState.IN_ELEVATOR)) {
+                player.forceState(PlayerState.IDLE);
             }
         }
     });
@@ -512,9 +509,8 @@ getClickedFloorIndex(y) {
         }
     }
 
-    console.log("→ No valid floor clicked");
     return -1;
 }
 
 
-} 
+}

--- a/js/Player.js
+++ b/js/Player.js
@@ -5,32 +5,45 @@
 class Player {
     /**
      * Initialize a new player character.
-     * 
+     *
      * @param {string} firstName - Player's first name
      * @param {string} lastName - Player's last name
      * @param {number} x - Initial x position
      * @param {number} y - Initial y position
+     * @param {string} spriteKey - Sprite sheet key
+     * @param {number} floorIndex - Starting floor (default 0)
      */
     constructor(firstName, lastName, x, y, spriteKey, floorIndex = 0) {
         this.firstName = firstName;
         this.lastName = lastName;
         this.x = x;
         this.y = y;
-        this.facingRight = true;  // Direction player is facing
+        this.facingRight = true;
         this.speed = GameConfig.CHAR_SPEED;
-        this.isWalking = false;  // Current movement state
-        
+
         this.spriteKey = spriteKey;
         this.currentFloor = floorIndex;
         this.vx = 0;
         this.targetX = null;
         this.deferredTargetX = null;
-        this.waitingForElevator = false;
         this.targetFloor = null;
-        this.inElevator = false;
-        this.walkingThroughDoor = false;
-        this.elevatorClickTimer  = null;
-        
+        this.elevatorClickTimer = null;
+
+        // State machine replaces: isWalking, waitingForElevator, inElevator,
+        // walkingThroughDoor, hasEnteredDoor, isIdling, playerCommandedMovement
+        this.stateMachine = new PlayerStateMachine(PlayerState.IDLE);
+
+        // Mode flag — determines behavior mode, not a movement state
+        this.isAutomated = false;
+
+        // Automation properties (initialized by GameScene.initializeNPCBehaviors)
+        this.direction = 1;
+        this.automatedSpeed = GameConfig.CHAR_SPEED * 0.4;
+        this.idleTimer = 0;
+        this.idleDuration = 0;
+        this.minX = 0;
+        this.maxX = 0;
+
         // Status attributes (0-100 scale)
         this.thirst = 100;  // 100 = fully hydrated, 0 = extremely thirsty
         this.hunger = 100;  // 100 = full, 0 = starving
@@ -38,32 +51,72 @@ class Player {
         this.toilet = 100;  // 100 = no need, 0 = urgent need
     }
 
+    // ── State convenience methods ──────────────────────────────────────
 
+    /** @returns {string} Current PlayerState value */
+    get state() { return this.stateMachine.state; }
+
+    /**
+     * Attempt a validated state transition.
+     * @param {string} newState - A PlayerState value
+     * @returns {boolean} Whether the transition succeeded
+     */
+    setState(newState) { return this.stateMachine.setState(newState); }
+
+    /**
+     * Force-set state (for cancellations / recovery).
+     * @param {string} newState - A PlayerState value
+     */
+    forceState(newState) { this.stateMachine.forceState(newState); }
+
+    /**
+     * @param {string} state - A PlayerState value
+     * @returns {boolean}
+     */
+    is(state) { return this.stateMachine.is(state); }
+
+    /**
+     * @param {...string} states - PlayerState values
+     * @returns {boolean}
+     */
+    isAnyOf(...states) { return this.stateMachine.isAnyOf(...states); }
+
+    // ── Movement ───────────────────────────────────────────────────────
+
+    /**
+     * Move toward targetX. Returns true if the target was reached.
+     * Does NOT manage state transitions — callers are responsible for that.
+     * @param {number} dt - Delta time in seconds
+     * @returns {boolean} Whether the player reached the target
+     */
     moveTowardTarget(dt) {
         if (this.targetX !== null) {
             const dx = this.targetX - this.x;
             const dir = Math.sign(dx);
             this.vx = dir * this.speed;
             this.x += this.vx * dt;
-            this.isWalking = true;
             this.facingRight = dir > 0;
 
             if (Math.abs(dx) < 2) {
                 this.x = this.targetX;
                 this.stop();
+                return true;
             }
+            return false;
         } else {
             this.vx = 0;
-            this.isWalking = false;
+            return false;
         }
     }
 
+    /**
+     * Halt movement (physics only — does not change state).
+     */
     stop() {
         this.vx = 0;
         this.targetX = null;
-        this.isWalking = false;
     }
-    
+
     /**
      * Update player status values over time
      * @param {number} dt - Delta time in seconds
@@ -71,14 +124,14 @@ class Player {
     updateStatus(dt) {
         // Status degradation rates per second
         const THIRST_RATE = 0.5;  // Lose 0.5% thirst per second
-        const HUNGER_RATE = 0.3;  // Lose 0.3% hunger per second  
+        const HUNGER_RATE = 0.3;  // Lose 0.3% hunger per second
         const SLEEP_RATE = 0.2;   // Lose 0.2% sleep per second
         const TOILET_RATE = 0.4;  // Lose 0.4% toilet per second
-        
+
         // Update status values
         this.thirst = Math.max(0, this.thirst - (THIRST_RATE * dt));
         this.hunger = Math.max(0, this.hunger - (HUNGER_RATE * dt));
         this.sleep = Math.max(0, this.sleep - (SLEEP_RATE * dt));
         this.toilet = Math.max(0, this.toilet - (TOILET_RATE * dt));
     }
-} 
+}

--- a/js/PlayerStateMachine.js
+++ b/js/PlayerStateMachine.js
@@ -1,0 +1,144 @@
+/**
+ * Player state constants.
+ * Replaces scattered boolean flags (isWalking, waitingForElevator, inElevator,
+ * walkingThroughDoor, hasEnteredDoor, isIdling, playerCommandedMovement) with
+ * a single, explicit state value.
+ */
+const PlayerState = Object.freeze({
+    IDLE: 'IDLE',
+    WALKING: 'WALKING',
+    AUTOMATED_IDLE: 'AUTOMATED_IDLE',
+    AUTOMATED_WALKING: 'AUTOMATED_WALKING',
+    WALKING_TO_ELEVATOR: 'WALKING_TO_ELEVATOR',
+    WAITING_FOR_ELEVATOR: 'WAITING_FOR_ELEVATOR',
+    IN_ELEVATOR: 'IN_ELEVATOR',
+    WALKING_THROUGH_DOOR: 'WALKING_THROUGH_DOOR',
+});
+
+/**
+ * Valid state transitions. Any transition not listed here will be rejected
+ * by setState() (use forceState() for recovery / cancellation scenarios).
+ */
+const VALID_TRANSITIONS = {
+    [PlayerState.IDLE]: [
+        PlayerState.WALKING,
+        PlayerState.AUTOMATED_IDLE,
+        PlayerState.AUTOMATED_WALKING,
+        PlayerState.WALKING_TO_ELEVATOR,
+    ],
+    [PlayerState.WALKING]: [
+        PlayerState.IDLE,
+        PlayerState.WALKING_TO_ELEVATOR,
+        PlayerState.WALKING_THROUGH_DOOR,
+        PlayerState.AUTOMATED_IDLE,
+        PlayerState.WAITING_FOR_ELEVATOR,
+    ],
+    [PlayerState.AUTOMATED_IDLE]: [
+        PlayerState.AUTOMATED_WALKING,
+        PlayerState.WALKING,
+        PlayerState.IDLE,
+        PlayerState.WALKING_TO_ELEVATOR,
+    ],
+    [PlayerState.AUTOMATED_WALKING]: [
+        PlayerState.AUTOMATED_IDLE,
+        PlayerState.WALKING,
+        PlayerState.IDLE,
+        PlayerState.WALKING_THROUGH_DOOR,
+        PlayerState.WALKING_TO_ELEVATOR,
+    ],
+    [PlayerState.WALKING_TO_ELEVATOR]: [
+        PlayerState.WAITING_FOR_ELEVATOR,
+        PlayerState.IDLE,
+        PlayerState.WALKING,
+        PlayerState.WALKING_THROUGH_DOOR,
+    ],
+    [PlayerState.WAITING_FOR_ELEVATOR]: [
+        PlayerState.IN_ELEVATOR,
+        PlayerState.IDLE,
+        PlayerState.WALKING,
+        PlayerState.WALKING_TO_ELEVATOR,
+    ],
+    [PlayerState.IN_ELEVATOR]: [
+        PlayerState.IDLE,
+        PlayerState.WALKING,
+        PlayerState.AUTOMATED_IDLE,
+    ],
+    [PlayerState.WALKING_THROUGH_DOOR]: [
+        PlayerState.WALKING,
+        PlayerState.IDLE,
+        PlayerState.AUTOMATED_WALKING,
+        PlayerState.AUTOMATED_IDLE,
+        PlayerState.WAITING_FOR_ELEVATOR,  // Can reach elevator zone while door cooldown active
+        PlayerState.WALKING_TO_ELEVATOR,   // Can click different floor during door transition
+    ],
+};
+
+/**
+ * Manages player state transitions with validation.
+ */
+class PlayerStateMachine {
+    /**
+     * @param {string} initialState - One of PlayerState values
+     */
+    constructor(initialState = PlayerState.IDLE) {
+        this._state = initialState;
+        this._previousState = null;
+    }
+
+    /** @returns {string} Current state */
+    get state() {
+        return this._state;
+    }
+
+    /** @returns {string|null} Previous state before last transition */
+    get previousState() {
+        return this._previousState;
+    }
+
+    /**
+     * Attempt a validated state transition.
+     * @param {string} newState - Target state
+     * @returns {boolean} Whether the transition succeeded
+     */
+    setState(newState) {
+        if (newState === this._state) return true;
+
+        const valid = VALID_TRANSITIONS[this._state];
+        if (!valid || !valid.includes(newState)) {
+            console.warn(`Invalid state transition: ${this._state} → ${newState}`);
+            return false;
+        }
+
+        this._previousState = this._state;
+        this._state = newState;
+        return true;
+    }
+
+    /**
+     * Force-set state without validation. Use for user-initiated cancellations
+     * or recovery scenarios where the normal transition graph doesn't apply.
+     * @param {string} newState - Target state
+     */
+    forceState(newState) {
+        this._previousState = this._state;
+        this._state = newState;
+    }
+
+    /**
+     * Check if current state matches.
+     * @param {string} state
+     * @returns {boolean}
+     */
+    is(state) {
+        return this._state === state;
+    }
+
+    /**
+     * Check if current state is any of the given states.
+     * @param {...string} states
+     * @returns {boolean}
+     */
+    isAnyOf(...states) {
+        return states.includes(this._state);
+    }
+}

--- a/js/managers/DoorManager.js
+++ b/js/managers/DoorManager.js
@@ -34,7 +34,8 @@ DoorManager.prototype.addDoor = function (floor, x, width = 32, height = 60, doo
 };
 
 DoorManager.prototype.checkDoorCollision = function (player, dx) {
-    if (player.hasEnteredDoor || player.walkingThroughDoor) return null;
+    // State machine check replaces: player.hasEnteredDoor || player.walkingThroughDoor
+    if (player.is(PlayerState.WALKING_THROUGH_DOOR)) return null;
 
     return this.doors.find(door =>
         door.floor === player.currentFloor &&
@@ -50,13 +51,12 @@ DoorManager.prototype.tryOpenDoor = function (player, dx) {
 
     // Pause movement
     const originalTargetX = player.targetX;
+    const wasAutomatedWalking = player.is(PlayerState.AUTOMATED_WALKING);
     player.targetX = null;
-
     player.vx = 0;
-    const directionAtStart = Math.sign(dx);
 
-    player.hasEnteredDoor = true;
-    player.walkingThroughDoor = true;
+    // Transition to door state
+    player.forceState(PlayerState.WALKING_THROUGH_DOOR);
     door.isOpen = true;
 
     // Visual switch: hide closed, show opened
@@ -64,12 +64,8 @@ DoorManager.prototype.tryOpenDoor = function (player, dx) {
     door.openedSprite.setVisible(true);
 
     this.scene.time.delayedCall(200, () => {
-        if (originalTargetX !== null && player.walkingThroughDoor) {
+        if (player.is(PlayerState.WALKING_THROUGH_DOOR) && originalTargetX !== null) {
             player.targetX = originalTargetX;
-            // Make sure playerCommandedMovement flag is preserved
-            if (player.playerCommandedMovement === undefined) {
-                player.playerCommandedMovement = !player.isAutomated;
-            }
         }
     });
 
@@ -77,7 +73,24 @@ DoorManager.prototype.tryOpenDoor = function (player, dx) {
         door.isOpen = false;
         door.closedSprite.setVisible(true);
         door.openedSprite.setVisible(false);
-        player.hasEnteredDoor = false;
-        player.walkingThroughDoor = false;
+
+        // Transition out of door state if still in it
+        if (player.is(PlayerState.WALKING_THROUGH_DOOR)) {
+            if (player.isAutomated) {
+                if (player.targetX !== null) {
+                    player.forceState(PlayerState.AUTOMATED_WALKING);
+                } else {
+                    player.forceState(PlayerState.AUTOMATED_IDLE);
+                    player.idleTimer = 0;
+                    player.idleDuration = 1 + Math.random() * 2;
+                }
+            } else {
+                if (player.targetX !== null) {
+                    player.forceState(PlayerState.WALKING);
+                } else {
+                    player.forceState(PlayerState.IDLE);
+                }
+            }
+        }
     });
 };

--- a/js/managers/ElevatorManager.js
+++ b/js/managers/ElevatorManager.js
@@ -25,7 +25,7 @@ class ElevatorManager {
             const backdropRT = this.scene.add.renderTexture(elevatorX, elevatorY + 5, 32, 32);
             backdropRT.setOrigin(0.5, 1);
             backdropRT.setDepth(0);
-            backdropRT.setScale(2); 
+            backdropRT.setScale(2);
 
             // Top-left of red background is tile index 512
             const indices = [1225, 1226, 1260, 1261];
@@ -50,11 +50,11 @@ class ElevatorManager {
     }
 
     requestElevator(player, targetFloor) {
-        player.waitingForElevator = true;
+        // Player should already be in WAITING_FOR_ELEVATOR state
         player.targetFloor = targetFloor;
 
         if (!this.activeRequest) {
-        
+
             this.activeRequest = { player, targetFloor };
             this.processQueue();
         }
@@ -62,7 +62,7 @@ class ElevatorManager {
 
     processQueue() {
         if (this.isLocked || !this.activeRequest) return;
-        
+
         const { player } = this.activeRequest;
         const startFloor = this.elevatorCurrentFloor;
         const endFloor = player.currentFloor;
@@ -72,7 +72,7 @@ class ElevatorManager {
             this.beginBoarding();
         } else {
             this.moveToFloor(endFloor, () => {
-            
+
                 this.beginBoarding();
             });
         }
@@ -91,18 +91,18 @@ class ElevatorManager {
             callback: () => {
                 this.elevatorCurrentFloor += direction;
                 count++;
-                
+
                 // Only flicker light off if not at target floor yet
                 if (count < steps) {
                     this.scene.time.delayedCall(500, () => {
                         this.elevatorLightFlicker(0);
                     });
                 }
-                
+
                 // Move elevator light to match new floor
                 this.elevatorLight.y = GameConfig.getElevatorY(this.elevatorCurrentFloor);
                 this.elevatorLightFlicker(1);
-                
+
                 if (count === steps) {
                     timer.remove();
                     onArriveCallback();
@@ -118,7 +118,7 @@ class ElevatorManager {
 
         const hasBoarders = this.scene.players.some(({ player }) =>
             player.currentFloor === floor &&
-            player.waitingForElevator &&
+            player.is(PlayerState.WAITING_FOR_ELEVATOR) &&
             Math.sign(player.targetFloor - player.currentFloor) === direction
         );
 
@@ -134,20 +134,27 @@ class ElevatorManager {
                     player.currentFloor = floor;
                     player.y = GameConfig.getPlayerFloorY(floor);
                     player.targetFloor = null;
-                    player.waitingForElevator = false;
                     player.spriteRef.setVisible(true);
                     if (player.deferredTargetX !== undefined) {
                         player.targetX = player.deferredTargetX;
                         delete player.deferredTargetX;
+                        player.forceState(PlayerState.WALKING);
+                    } else {
+                        if (player.isAutomated) {
+                            player.forceState(PlayerState.AUTOMATED_IDLE);
+                            player.idleTimer = 0;
+                            player.idleDuration = 1 + Math.random() * 2;
+                        } else {
+                            player.forceState(PlayerState.IDLE);
+                        }
                     }
-                    player.inElevator = false;
                 });
                 this.boardedPlayers = this.boardedPlayers.filter(p => p.targetFloor !== floor);
 
                 const newBoarders = this.scene.players
                     .filter(({ player }) =>
                         player.currentFloor === floor &&
-                        player.waitingForElevator &&
+                        player.is(PlayerState.WAITING_FOR_ELEVATOR) &&
                         Math.sign(player.targetFloor - player.currentFloor) === direction
                     )
                     .map(({ player }) => player);
@@ -189,8 +196,7 @@ class ElevatorManager {
                     player.x = targetX;
                     player.vx = 0;
                     player.spriteRef.setDepth(0); // Behind the elevator door
-                    player.inElevator = true;
-                    player.waitingForElevator = false;
+                    player.setState(PlayerState.IN_ELEVATOR);
                     this.boardedPlayers.push(player);
                     walkInterval.remove();
 
@@ -217,25 +223,32 @@ class ElevatorManager {
             player.y = GameConfig.getPlayerFloorY(floor);
             player.currentFloor = floor;
             player.targetFloor = null;
-            player.waitingForElevator = false;
-            player.inElevator = false;
             player.spriteRef.setDepth(20); // Return to default front layer
             if (player.deferredTargetX !== undefined) {
                 player.targetX = player.deferredTargetX;
                 delete player.deferredTargetX;
+                player.forceState(PlayerState.WALKING);
+            } else {
+                if (player.isAutomated) {
+                    player.forceState(PlayerState.AUTOMATED_IDLE);
+                    player.idleTimer = 0;
+                    player.idleDuration = 1 + Math.random() * 2;
+                } else {
+                    player.forceState(PlayerState.IDLE);
+                }
             }
             walkInterval.remove();
             this.sequentialExiting(players, floor, onComplete);
-   
+
         }
     });
 }
 
 continueElevatorTravel(originalTarget, direction) {
     let stepsRemaining = Math.abs(originalTarget - this.elevatorCurrentFloor);
-    
+
     const step = () => {
-        
+
         if (stepsRemaining <= 0) {
             this.isLocked = false;
             this.activeRequest = null;
@@ -250,7 +263,7 @@ continueElevatorTravel(originalTarget, direction) {
                 };
                 this.processQueue();
             } else {
-                const next = this.scene.players.find(({ player }) => player.waitingForElevator);
+                const next = this.scene.players.find(({ player }) => player.is(PlayerState.WAITING_FOR_ELEVATOR));
                 if (next) {
                     this.activeRequest = {
                         player: next.player,
@@ -288,7 +301,7 @@ continueElevatorTravel(originalTarget, direction) {
         const newBoarders = this.scene.players
             .filter(({ player }) =>
                 player.currentFloor === floor &&
-                player.waitingForElevator &&
+                player.is(PlayerState.WAITING_FOR_ELEVATOR) &&
                 Math.sign(player.targetFloor - player.currentFloor) === direction
             )
             .map(({ player }) => player);

--- a/js/managers/InputManager.js
+++ b/js/managers/InputManager.js
@@ -10,16 +10,23 @@ class InputManager {
             if (pointer.rightButtonDown()) return; // handled elsewhere for selection
 
             const selected = this.scene.selectedPlayer;
-            
+
             if (this.scene.elevatorManager.boardedPlayers.includes(selected)) return;
-            
+
             if (selected) {
-                if(selected.elevatorClickTimer)
+                if (selected.elevatorClickTimer)
                        selected.elevatorClickTimer.remove();
 
-                selected.waitingForElevator = false;
+                // Cancel waiting/door states on new click
+                if (selected.isAnyOf(PlayerState.WAITING_FOR_ELEVATOR, PlayerState.WALKING_THROUGH_DOOR, PlayerState.WALKING_TO_ELEVATOR)) {
+                    selected.forceState(PlayerState.IDLE);
+                }
+
                 selected.targetX = pointer.worldX;
-                selected.walkingThroughDoor = false;
+                if (selected.is(PlayerState.IDLE)) {
+                    selected.setState(PlayerState.WALKING);
+                }
+                // If already WALKING, state stays — just new targetX
             }
         });
     }

--- a/tests/Player.test.js
+++ b/tests/Player.test.js
@@ -35,17 +35,22 @@ describe('Player', () => {
         });
 
         it('should initialize movement state as idle', () => {
-            expect(player.isWalking).toBe(false);
             expect(player.vx).toBe(0);
             expect(player.targetX).toBeNull();
             expect(player.facingRight).toBe(true);
         });
 
         it('should initialize elevator state as inactive', () => {
-            expect(player.waitingForElevator).toBe(false);
-            expect(player.inElevator).toBe(false);
             expect(player.targetFloor).toBeNull();
-            expect(player.walkingThroughDoor).toBe(false);
+            expect(player.deferredTargetX).toBeNull();
+        });
+
+        it('should initialize state machine in IDLE state', () => {
+            expect(player.state).toBe(PlayerState.IDLE);
+        });
+
+        it('should initialize isAutomated to false', () => {
+            expect(player.isAutomated).toBe(false);
         });
     });
 
@@ -57,7 +62,6 @@ describe('Player', () => {
             expect(player.vx).toBeGreaterThan(0);
             expect(player.x).toBeGreaterThan(400);
             expect(player.facingRight).toBe(true);
-            expect(player.isWalking).toBe(true);
         });
 
         it('should move left toward a target to the left', () => {
@@ -67,26 +71,33 @@ describe('Player', () => {
             expect(player.vx).toBeLessThan(0);
             expect(player.x).toBeLessThan(400);
             expect(player.facingRight).toBe(false);
-            expect(player.isWalking).toBe(true);
         });
 
-        it('should stop when within 2px of target', () => {
+        it('should return true and stop when within 2px of target', () => {
             player.targetX = 401; // 1px away
-            player.moveTowardTarget(0.001);
+            const reached = player.moveTowardTarget(0.001);
 
+            expect(reached).toBe(true);
             expect(player.x).toBe(401);
             expect(player.vx).toBe(0);
             expect(player.targetX).toBeNull();
-            expect(player.isWalking).toBe(false);
         });
 
-        it('should not move when targetX is null', () => {
+        it('should return false when targetX is null', () => {
             player.targetX = null;
-            player.moveTowardTarget(0.1);
+            const reached = player.moveTowardTarget(0.1);
 
+            expect(reached).toBe(false);
             expect(player.x).toBe(400);
             expect(player.vx).toBe(0);
-            expect(player.isWalking).toBe(false);
+        });
+
+        it('should return false when still moving', () => {
+            player.targetX = 600;
+            const reached = player.moveTowardTarget(0.5);
+
+            expect(reached).toBe(false);
+            expect(player.x).toBeCloseTo(450, 0);
         });
 
         it('should update position based on speed and delta time', () => {
@@ -100,16 +111,22 @@ describe('Player', () => {
     });
 
     describe('stop', () => {
-        it('should reset velocity, target, and walking state', () => {
+        it('should reset velocity and target', () => {
             player.vx = 100;
             player.targetX = 500;
-            player.isWalking = true;
 
             player.stop();
 
             expect(player.vx).toBe(0);
             expect(player.targetX).toBeNull();
-            expect(player.isWalking).toBe(false);
+        });
+
+        it('should not change state machine state', () => {
+            player.setState(PlayerState.WALKING);
+            player.stop();
+
+            // stop() is physics-only, does not manage state
+            expect(player.state).toBe(PlayerState.WALKING);
         });
     });
 
@@ -164,6 +181,154 @@ describe('Player', () => {
             expect(player.hunger).toBe(0);
             expect(player.sleep).toBe(0);
             expect(player.toilet).toBe(0);
+        });
+    });
+
+    describe('state machine integration', () => {
+        it('should expose state convenience methods', () => {
+            expect(player.state).toBe(PlayerState.IDLE);
+            expect(player.is(PlayerState.IDLE)).toBe(true);
+            expect(player.isAnyOf(PlayerState.IDLE, PlayerState.WALKING)).toBe(true);
+            expect(player.isAnyOf(PlayerState.WALKING, PlayerState.IN_ELEVATOR)).toBe(false);
+        });
+
+        it('should allow valid transitions via setState', () => {
+            const result = player.setState(PlayerState.WALKING);
+            expect(result).toBe(true);
+            expect(player.state).toBe(PlayerState.WALKING);
+        });
+
+        it('should reject invalid transitions via setState', () => {
+            // IDLE → IN_ELEVATOR is not a valid transition
+            const result = player.setState(PlayerState.IN_ELEVATOR);
+            expect(result).toBe(false);
+            expect(player.state).toBe(PlayerState.IDLE);
+        });
+
+        it('should allow forceState to bypass validation', () => {
+            player.forceState(PlayerState.IN_ELEVATOR);
+            expect(player.state).toBe(PlayerState.IN_ELEVATOR);
+        });
+    });
+});
+
+describe('PlayerStateMachine', () => {
+    let sm;
+
+    beforeEach(() => {
+        sm = new PlayerStateMachine(PlayerState.IDLE);
+    });
+
+    describe('constructor', () => {
+        it('should start in the given initial state', () => {
+            expect(sm.state).toBe(PlayerState.IDLE);
+        });
+
+        it('should have null previousState initially', () => {
+            expect(sm.previousState).toBeNull();
+        });
+    });
+
+    describe('setState', () => {
+        it('should transition between valid states', () => {
+            expect(sm.setState(PlayerState.WALKING)).toBe(true);
+            expect(sm.state).toBe(PlayerState.WALKING);
+        });
+
+        it('should track previous state', () => {
+            sm.setState(PlayerState.WALKING);
+            expect(sm.previousState).toBe(PlayerState.IDLE);
+        });
+
+        it('should reject invalid transitions', () => {
+            const warn = jest.spyOn(console, 'warn').mockImplementation();
+            expect(sm.setState(PlayerState.IN_ELEVATOR)).toBe(false);
+            expect(sm.state).toBe(PlayerState.IDLE);
+            warn.mockRestore();
+        });
+
+        it('should return true for same-state transitions (no-op)', () => {
+            expect(sm.setState(PlayerState.IDLE)).toBe(true);
+            expect(sm.state).toBe(PlayerState.IDLE);
+        });
+    });
+
+    describe('forceState', () => {
+        it('should bypass validation', () => {
+            sm.forceState(PlayerState.IN_ELEVATOR);
+            expect(sm.state).toBe(PlayerState.IN_ELEVATOR);
+            expect(sm.previousState).toBe(PlayerState.IDLE);
+        });
+    });
+
+    describe('is / isAnyOf', () => {
+        it('should check current state', () => {
+            expect(sm.is(PlayerState.IDLE)).toBe(true);
+            expect(sm.is(PlayerState.WALKING)).toBe(false);
+        });
+
+        it('should check against multiple states', () => {
+            expect(sm.isAnyOf(PlayerState.IDLE, PlayerState.WALKING)).toBe(true);
+            expect(sm.isAnyOf(PlayerState.WALKING, PlayerState.IN_ELEVATOR)).toBe(false);
+        });
+    });
+
+    describe('full transition chains', () => {
+        it('should support IDLE → WALKING → IDLE', () => {
+            expect(sm.setState(PlayerState.WALKING)).toBe(true);
+            expect(sm.setState(PlayerState.IDLE)).toBe(true);
+            expect(sm.state).toBe(PlayerState.IDLE);
+        });
+
+        it('should support automated cycle: IDLE → AUTO_IDLE → AUTO_WALKING → AUTO_IDLE', () => {
+            sm.setState(PlayerState.AUTOMATED_IDLE);
+            expect(sm.state).toBe(PlayerState.AUTOMATED_IDLE);
+
+            sm.setState(PlayerState.AUTOMATED_WALKING);
+            expect(sm.state).toBe(PlayerState.AUTOMATED_WALKING);
+
+            sm.setState(PlayerState.AUTOMATED_IDLE);
+            expect(sm.state).toBe(PlayerState.AUTOMATED_IDLE);
+        });
+
+        it('should support elevator flow: IDLE → WALKING → WALK_TO_ELEV → WAITING → IN_ELEV → IDLE', () => {
+            sm.setState(PlayerState.WALKING);
+            sm.setState(PlayerState.WALKING_TO_ELEVATOR);
+            sm.setState(PlayerState.WAITING_FOR_ELEVATOR);
+            sm.setState(PlayerState.IN_ELEVATOR);
+            sm.setState(PlayerState.IDLE);
+            expect(sm.state).toBe(PlayerState.IDLE);
+        });
+
+        it('should support door flow: WALKING → DOOR → WALKING', () => {
+            sm.setState(PlayerState.WALKING);
+            sm.setState(PlayerState.WALKING_THROUGH_DOOR);
+            sm.setState(PlayerState.WALKING);
+            expect(sm.state).toBe(PlayerState.WALKING);
+        });
+
+        it('should support automated door flow: AUTO_WALKING → DOOR → AUTO_WALKING', () => {
+            sm.setState(PlayerState.AUTOMATED_IDLE);
+            sm.setState(PlayerState.AUTOMATED_WALKING);
+            sm.setState(PlayerState.WALKING_THROUGH_DOOR);
+            sm.setState(PlayerState.AUTOMATED_WALKING);
+            expect(sm.state).toBe(PlayerState.AUTOMATED_WALKING);
+        });
+
+        it('should support door-to-elevator flow: DOOR → WAITING_FOR_ELEVATOR', () => {
+            // Player walks through door on the way to elevator, reaches elevator
+            // zone while door cooldown (1000ms) is still active
+            sm.setState(PlayerState.WALKING);
+            sm.setState(PlayerState.WALKING_THROUGH_DOOR);
+            expect(sm.setState(PlayerState.WAITING_FOR_ELEVATOR)).toBe(true);
+            expect(sm.state).toBe(PlayerState.WAITING_FOR_ELEVATOR);
+        });
+
+        it('should support door-to-elevator-click flow: DOOR → WALKING_TO_ELEVATOR', () => {
+            sm.setState(PlayerState.WALKING);
+            sm.setState(PlayerState.WALKING_THROUGH_DOOR);
+            expect(sm.setState(PlayerState.WALKING_TO_ELEVATOR)).toBe(true);
+            expect(sm.state).toBe(PlayerState.WALKING_TO_ELEVATOR);
         });
     });
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -3,7 +3,6 @@ const path = require('path');
 
 function loadScript(filePath) {
     const code = fs.readFileSync(path.resolve(__dirname, '..', filePath), 'utf-8');
-    // Wrap in a function that returns the class, then assign to global
     return eval(code + '\n;typeof ' + getClassName(filePath) + ' !== "undefined" ? ' + getClassName(filePath) + ' : undefined;');
 }
 
@@ -11,6 +10,24 @@ function getClassName(filePath) {
     return path.basename(filePath, '.js');
 }
 
-// Load source files into the global scope (order matters — GameConfig first)
+function loadMultipleExports(filePath, names) {
+    const code = fs.readFileSync(path.resolve(__dirname, '..', filePath), 'utf-8');
+    const result = {};
+    // Build a return expression that captures all named exports
+    const returnExpr = names.map(n => `"${n}": typeof ${n} !== "undefined" ? ${n} : undefined`).join(',');
+    const wrapped = code + '\n;({' + returnExpr + '})';
+    const exports = eval(wrapped);
+    names.forEach(n => {
+        if (exports[n] !== undefined) {
+            global[n] = exports[n];
+        }
+    });
+}
+
+// Load source files into the global scope (order matters)
 global.GameConfig = loadScript('js/GameConfig.js');
+
+// PlayerStateMachine.js defines PlayerState, VALID_TRANSITIONS, and PlayerStateMachine
+loadMultipleExports('js/PlayerStateMachine.js', ['PlayerState', 'VALID_TRANSITIONS', 'PlayerStateMachine']);
+
 global.Player = loadScript('js/Player.js');


### PR DESCRIPTION
Introduce PlayerStateMachine with 8 states (IDLE, WALKING, AUTOMATED_IDLE, AUTOMATED_WALKING, WALKING_TO_ELEVATOR, WAITING_FOR_ELEVATOR, IN_ELEVATOR, WALKING_THROUGH_DOOR) replacing 8+ scattered boolean flags (isWalking, waitingForElevator, inElevator, walkingThroughDoor, hasEnteredDoor, isIdling, playerCommandedMovement). Validated transitions prevent impossible state combinations.

Also fixes elevator boarding bug where door cooldown blocked the WALKING_THROUGH_DOOR → WAITING_FOR_ELEVATOR transition on floors with doors between the player and elevator.

Tests: 44 passing (up from 20).